### PR TITLE
Chore/upgrade scanoss dependency to v0.16.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "react-virtualized": "^9.22.3",
         "react-virtualized-tree": "^3.4.1",
         "regenerator-runtime": "^0.13.5",
-        "scanoss": "0.16.3",
+        "scanoss": "^0.16.4",
         "sort-paths": "^1.1.1",
         "source-map-support": "^0.5.19",
         "translation-check": "^1.0.2",
@@ -15689,9 +15689,9 @@
       }
     },
     "node_modules/scanoss": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.16.3.tgz",
-      "integrity": "sha512-1dj5bEFpTPMCuE+7HQWP8USJX3/CHggzLPTX6GslkYrY0OA72G0vRO8+WgeMZl69DuuU+h66jZL9SOdFEroRjg==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.16.4.tgz",
+      "integrity": "sha512-dTTlxrtTNvxP408bBy4lhZImdqxBHY9Ko5woOA7P+3c67SR7271pKT4XiLwIHUcB6suMPmAgOhu+6EB1+Q0dyg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "react-virtualized": "^9.22.3",
     "react-virtualized-tree": "^3.4.1",
     "regenerator-runtime": "^0.13.5",
-    "scanoss": "^0.16.3",
+    "scanoss": "^0.16.4",
     "sort-paths": "^1.1.1",
     "source-map-support": "^0.5.19",
     "translation-check": "^1.0.2",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fossity-probe",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fossity-probe",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "hasInstallScript": true,
       "license": "GPL-2.0"
     }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fossity-probe",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "The Fossity Probe captures basic information and fingerprints from your code.",
   "license": "GPL-2.0",
   "author": {


### PR DESCRIPTION
### **WHAT**

Upgraded scanoss dependency to fix parsing issues on  go.mod and go.sum files.

## Changed
- Upgraded scanoss dependency to v0.16.4
- Upgraded app version to v1.3.4
