### PR TITLE
chore(build): SP-2199 Re-enable Code Signing pipeline for Windows builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact_w
+          name: artifact_w_unsigned
           path: |
             release/build/${{ env.ARTIFACT_NAME_PREFIX }}*.exe
             release/build/latest.yml
@@ -44,48 +44,48 @@ jobs:
           retention-days: 2
 
 
-#  build_w_sign:
-#    name: "Sign with CodeSignTool"
-#    needs: [build_w]
-#    runs-on: ubuntu-latest
-#    steps:
-#
-#      - name: Download artifact W unsigned
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: artifact_w_unsigned
-#
-#      #This stage locates the unsigned .exe binary and move to win_unsigned folder.
-#      #CodeSignTool does not support reading and writting into the same filepath
-#      - name: Find Windows Artifact Path
-#        id: win-path-artifact
-#        run: |
-#          export WIN_BINARY_FILEPATH=$(ls ${{ env.ARTIFACT_NAME_PREFIX }}*.exe)
-#          mkdir win_unsigned
-#          mv "$WIN_BINARY_FILEPATH" win_unsigned/
-#          echo "ARTIFACT_WIN_PATH=win_unsigned/$WIN_BINARY_FILEPATH" >> "$GITHUB_OUTPUT"
-#
-#      - name: Sign Windows Artifact with CodeSignTool
-#        uses: sslcom/actions-codesigner@develop
-#        env:
-#          ARTIFACT_WIN_PATH: ${{ steps.win-path-artifact.outputs.ARTIFACT_WIN_PATH }}
-#        with:
-#          command: sign
-#          username: ${{secrets.ES_USERNAME}}
-#          password: ${{secrets.ES_PASSWORD}}
-#          credential_id: ${{secrets.CREDENTIAL_ID}}
-#          totp_secret: ${{secrets.ES_TOTP_SECRET}}
-#          file_path:  ${GITHUB_WORKSPACE}/${{ env.ARTIFACT_WIN_PATH }}
-#          output_path:  ${GITHUB_WORKSPACE}
-#
-#      - uses: actions/upload-artifact@v4
-#        with:
-#          name: artifact_w
-#          path: |
-#            ${{ env.ARTIFACT_NAME_PREFIX }}*.exe
-#            latest.yml
-#            *exe.blockmap
-#          retention-days: 2
+  build_w_sign:
+    name: "Sign with CodeSignTool"
+    needs: [build_w]
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download artifact W unsigned
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_w_unsigned
+
+      #This stage locates the unsigned .exe binary and move to win_unsigned folder.
+      #CodeSignTool does not support reading and writting into the same filepath
+      - name: Find Windows Artifact Path
+        id: win-path-artifact
+        run: |
+          export WIN_BINARY_FILEPATH=$(ls ${{ env.ARTIFACT_NAME_PREFIX }}*.exe)
+          mkdir win_unsigned
+          mv "$WIN_BINARY_FILEPATH" win_unsigned/
+          echo "ARTIFACT_WIN_PATH=win_unsigned/$WIN_BINARY_FILEPATH" >> "$GITHUB_OUTPUT"
+
+      - name: Sign Windows Artifact with CodeSignTool
+        uses: sslcom/actions-codesigner@develop
+        env:
+          ARTIFACT_WIN_PATH: ${{ steps.win-path-artifact.outputs.ARTIFACT_WIN_PATH }}
+        with:
+          command: sign
+          username: ${{secrets.ES_USERNAME}}
+          password: ${{secrets.ES_PASSWORD}}
+          credential_id: ${{secrets.CREDENTIAL_ID}}
+          totp_secret: ${{secrets.ES_TOTP_SECRET}}
+          file_path:  ${GITHUB_WORKSPACE}/${{ env.ARTIFACT_WIN_PATH }}
+          output_path:  ${GITHUB_WORKSPACE}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact_w
+          path: |
+            ${{ env.ARTIFACT_NAME_PREFIX }}*.exe
+            latest.yml
+            *exe.blockmap
+          retention-days: 2
 
   build_m:
     name: "Build for MacOS"
@@ -162,7 +162,7 @@ jobs:
 
 
   create_release:
-    needs: [build_w, build_l, build_m]
+    needs: [build_w_sign, build_l, build_m]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
Re-enables Windows code signing pipeline that was disabled due to expired SSL.com certificates.

## Changes
- Uncommented `build_w_sign` job in publish workflow
- Updated artifact naming and pipeline dependencies
- Restored SSL.com CodeSignTool integration

## See Digital Signature
![image](https://github.com/user-attachments/assets/4670f1b4-35da-45a4-aaec-7ef550d77d03)
