### PR TITLE
fix(linux): FOS-698 AppImage sandbox crash on Ubuntu 24.04

### DIFF
--- a/appimage-fix.js
+++ b/appimage-fix.js
@@ -2,7 +2,7 @@ const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const appName = 'scanoss-workbench';
+const appName = 'fossity-probe';
 
 function isLinux(targets) {
   const re = /AppImage|snap|deb|rpm|freebsd|pacman/i;
@@ -13,15 +13,14 @@ async function afterPack({ targets, appOutDir }) {
   if (!isLinux(targets)) return;
   const scriptPath = path.join(appOutDir, appName);
   const script = `#!/bin/bash\n"\${BASH_SOURCE%/*}"/${appName}.bin "$@" --no-sandbox`;
-  new Promise((resolve) => {
+  await new Promise((resolve) => {
     const child = child_process.exec(`mv ${appName} ${appName}.bin`, { cwd: appOutDir });
     child.on('exit', () => {
       resolve();
     });
-  }).then(() => {
-    fs.writeFileSync(scriptPath, script);
-    child_process.exec(`chmod +x ${appName}`, { cwd: appOutDir });
   });
+  fs.writeFileSync(scriptPath, script);
+  child_process.execSync(`chmod +x ${appName}`, { cwd: appOutDir });
 }
 
 module.exports = afterPack;

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
       "package.json"
     ],
     "afterSign": ".erb/scripts/notarize.js",
+    "afterPack": "./appimage-fix.js",
     "mac": {
       "notarize" : false,
       "target": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fossity-probe",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fossity-probe",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "hasInstallScript": true,
       "license": "GPL-2.0"
     }


### PR DESCRIPTION
## Summary
- Wires up the existing `appimage-fix.js` as an `afterPack` hook in electron-builder config
- Updates the app name from `scanoss-workbench` to `fossity-probe`
- Fixes async bug in the script (unawaited promise)

This applies the same fix already shipped for SBOM Workbench (SP-2052). The `afterPack` hook creates a wrapper script that launches the Electron binary with `--no-sandbox`, avoiding the Chrome SUID sandbox permission crash on Ubuntu 24.04+.

## Test plan
- [x] Built locally with `npm run package` — verified `fossity-probe.bin` and wrapper script are created in `release/build/linux-unpacked/`
- [x] Run the AppImage on Ubuntu 24.04 and confirm it launches without the sandbox error