### PR TITLE
fix(linux):SP-4216 Enable no-sandbox flag for AppImage on Ubuntu 24.04

### DIFF
--- a/appimage-fix.js
+++ b/appimage-fix.js
@@ -2,7 +2,7 @@ const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const appName = 'scanoss-workbench';
+const appName = 'fossity-probe';
 
 function isLinux(targets) {
   const re = /AppImage|snap|deb|rpm|freebsd|pacman/i;
@@ -13,15 +13,14 @@ async function afterPack({ targets, appOutDir }) {
   if (!isLinux(targets)) return;
   const scriptPath = path.join(appOutDir, appName);
   const script = `#!/bin/bash\n"\${BASH_SOURCE%/*}"/${appName}.bin "$@" --no-sandbox`;
-  new Promise((resolve) => {
+  await new Promise((resolve) => {
     const child = child_process.exec(`mv ${appName} ${appName}.bin`, { cwd: appOutDir });
     child.on('exit', () => {
       resolve();
     });
-  }).then(() => {
-    fs.writeFileSync(scriptPath, script);
-    child_process.exec(`chmod +x ${appName}`, { cwd: appOutDir });
   });
+  fs.writeFileSync(scriptPath, script);
+  child_process.execSync(`chmod +x ${appName}`, { cwd: appOutDir });
 }
 
 module.exports = afterPack;

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
       "package.json"
     ],
     "afterSign": ".erb/scripts/notarize.js",
+    "afterPack": "./appimage-fix.js",
     "mac": {
       "notarize" : false,
       "target": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fossity-probe",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fossity-probe",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "hasInstallScript": true,
       "license": "GPL-2.0"
     }


### PR DESCRIPTION
## Summary
- Added `afterPack` hook that wraps the Electron binary with a bash script adding `--no-sandbox` flag for Linux AppImage builds

## Test plan
- [ ] Build Linux AppImage via CI
- [ ] Test AppImage launches correctly on Ubuntu 24.04+